### PR TITLE
support use of /release/ in urls to match ember-api-docs app #43

### DIFF
--- a/app/routes/version.js
+++ b/app/routes/version.js
@@ -9,7 +9,9 @@ export default Route.extend({
     let applicationModel = this.modelFor('application');
     let version;
 
-    if (params.version === 'current') {
+    // We need to support legacy `current` urls, but we should use release
+    // in order to keep in step with ember-api-docs url convention
+    if (params.version === 'current' || params.version === 'release') {
       version = get(applicationModel, 'currentVersion');
     } else {
       version = params.version;

--- a/tests/acceptance/current-url-test.js
+++ b/tests/acceptance/current-url-test.js
@@ -3,10 +3,22 @@ import moduleForAcceptance from 'guides-app/tests/helpers/module-for-acceptance'
 
 moduleForAcceptance('Acceptance | current url');
 
+// We need to support legacy `current` urls, but we should use release
+// in order to keep in step with ember-api-docs url convention
+
 test('visiting /current-url', function(assert) {
   visit('/current');
   let page = this.application.__container__.lookup('service:page');
   andThen(function() {
+    let currentVersion = page.get('currentVersion');
+    assert.equal(find('.ember-basic-dropdown-trigger').text().trim(), currentVersion);
+  });
+});
+
+test('visiting /release-url', function (assert) {
+  visit('/release');
+  let page = this.application.__container__.lookup('service:page');
+  andThen(function () {
     let currentVersion = page.get('currentVersion');
     assert.equal(find('.ember-basic-dropdown-trigger').text().trim(), currentVersion);
   });


### PR DESCRIPTION
Closes #43 

Still supports `/current/` too