### PR TITLE
address ember-a11y-testing issues except color contrast #46

### DIFF
--- a/app/templates/components/main-footer.hbs
+++ b/app/templates/components/main-footer.hbs
@@ -35,11 +35,11 @@
       <div class="footer-contributions">
         <div class="contributor">
           <p>Hosted by:</p>
-          <a href="https://www.heroku.com/emberjs"><img src="/images/logos/vendors/heroku-logo.svg" class="logo-heroku"></a>
+          <a href="https://www.heroku.com/emberjs"><img src="/images/logos/vendors/heroku-logo.svg" class="logo-heroku" alt="Heroku logo"></a>
         </div>
         <div class="contributor">
           <p>CDN provided by:</p>
-          <a href="https://www.fastly.com"><img src="/images/logos/vendors/fastly-logo.svg" class="logo-fastly"></a>
+          <a href="https://www.fastly.com"><img src="/images/logos/vendors/fastly-logo.svg" class="logo-fastly" alt="Fastly logo"></a>
         </div>
       </div>
 

--- a/app/templates/components/main-header.hbs
+++ b/app/templates/components/main-header.hbs
@@ -28,6 +28,7 @@
 
         <li class="header-search">
           <form>
+            <label for="search-input" class="visually-hidden">Search the guides</label>
             <input type="text" id="search-input" class="search-input" placeholder="Search the guides"/>
           </form>
         </li>

--- a/app/templates/version.hbs
+++ b/app/templates/version.hbs
@@ -1,6 +1,6 @@
 <aside class="sidebar">
   <label for="version-select" class="visually-hidden">Guides version</label>
-  {{#power-select class="version-select" selected=model.version options=versions onchange=(action 'selectVersion') as |version|}}
+  {{#power-select class="version-select" ariaLabel=model.version selected=model.version options=versions onchange=(action 'selectVersion') as |version|}}
     {{version}}
   {{/power-select}}
 


### PR DESCRIPTION
Closes #46 

Minor changes, including hidden form labels and an `area-label` for the ember power select dropdown.

cc @MelSumner, just an FYI that I took a look at this. I fixed everything I saw except color contrast, since that's covered by upcoming styleguide improvements, and I skipped things that were deep in ember-power-select.