### PR TITLE
Fixing javascript free experience

### DIFF
--- a/lib/content-guides-generator/index.js
+++ b/lib/content-guides-generator/index.js
@@ -23,7 +23,7 @@ const VersionsSerializer = new Serializer('version', {
 
 const versions = yaml.safeLoad(readFileSync('node_modules/@ember/guides-source/versions.yml', 'utf8'));
 
-let premberVersions = [...versions.allVersions, 'current'];
+let premberVersions = [...versions.allVersions, 'current', 'release'];
 
 const urls = premberVersions.map(version => `/${version}`);
 

--- a/lib/content-guides-generator/index.js
+++ b/lib/content-guides-generator/index.js
@@ -28,7 +28,7 @@ let premberVersions = [...versions.allVersions, 'current', 'release'];
 const urls = premberVersions.map(version => `/${version}`);
 
 premberVersions.forEach((premberVersion) => {
-  const filesVersion = premberVersion === 'current' ? versions.currentVersion : premberVersion;
+  const filesVersion = ['current', 'release'].includes(premberVersion) ? versions.currentVersion : premberVersion;
   const paths = walkSync(`node_modules/@ember/guides-source/guides/${filesVersion}`);
 
   const mdFiles = paths.

--- a/static.json
+++ b/static.json
@@ -1,5 +1,10 @@
 {
   "https_only": true,
   "root": "dist",
-  "error_page": "_empty.html"
+  "error_page": "_empty.html",
+  "redirects": {
+    "/": {
+      "url": "/release/"
+    }
+  }
 }


### PR DESCRIPTION
A relatively simple change that will make the site work a lot better when Javascript is turned off.

Firstly I'm moving the ownership of the "/" => "/release/" down into the Nginx part of the stack. This means that people with Javascript turned off won't get a blank screen and need to **manually** add '/release/' to the URL for it to do anything.

The second thing I noticed is that we're not actually pre-rendering the 'release' version currently, because it was originally named 'current'. That's all fixed 🎉 