### PR TITLE
just make sure that track page isn't called in fastboot

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -20,7 +20,7 @@ const Router = EmberRouter.extend({
 
   _trackPage() {
     if(get(this, 'fastboot.isFastBoot')) {
-      return
+      return;
     }
 
     scheduleOnce('afterRender', this, () => {

--- a/app/router.js
+++ b/app/router.js
@@ -11,6 +11,7 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 
   metrics: service(),
+  fastboot: service(),
 
   didTransition() {
     this._super(...arguments);
@@ -18,6 +19,10 @@ const Router = EmberRouter.extend({
   },
 
   _trackPage() {
+    if(get(this, 'fastboot.isFastBoot')) {
+      return
+    }
+
     scheduleOnce('afterRender', this, () => {
       const page = this.get('url');
       const title = this.getWithDefault('currentRouteName', 'unknown');


### PR DESCRIPTION
I have a feeling this would have created a bunch of errors (that won't have made a difference) in the output log but I want to make sure it's not spamming the logs with errors if we don't need to 😂 