### PR TITLE
override color of code block comments to make them readable

### DIFF
--- a/app/styles/_prism-overrides.scss
+++ b/app/styles/_prism-overrides.scss
@@ -15,3 +15,8 @@ code > .diff-deletion {
 code .diff-operator {
   user-select: none;
 }
+
+code .token.comment {
+  color: #E6E6E6;
+
+}

--- a/app/styles/_prism-overrides.scss
+++ b/app/styles/_prism-overrides.scss
@@ -18,5 +18,4 @@ code .diff-operator {
 
 code .token.comment {
   color: #E6E6E6;
-
 }


### PR DESCRIPTION
Before, unreadable code comments
![screen shot 2018-05-17 at 11 05 53 pm](https://user-images.githubusercontent.com/16627268/40214240-9fba26b4-5a27-11e8-937e-504a85dc08fb.png)

Change comments to light grey so they are somewhat more legible
![screen shot 2018-05-17 at 11 08 09 pm](https://user-images.githubusercontent.com/16627268/40214242-a0f85e7e-5a27-11e8-9f8d-462da9c15444.png)
