### PR TITLE
fixing redirects of subfolders - Fixes 88

### DIFF
--- a/static.json
+++ b/static.json
@@ -7,8 +7,8 @@
     "/": {
       "url": "/release/"
     },
-    "/current/": {
-      "url": "/release/"
+    "/current/(.*)": {
+      "url": "/release/$1"
     }
   },
   "headers": {


### PR DESCRIPTION
This makes sure that any **deep** links into the `/current/` version are redirected to the same page in `/release/`