### PR TITLE
enabling preview of latest beta of guides-source

### DIFF
--- a/lib/content-guides-generator/index.js
+++ b/lib/content-guides-generator/index.js
@@ -7,7 +7,7 @@ const walkSync = require('walk-sync');
 const writeFile = require('broccoli-file-creator');
 const yaml = require('js-yaml');
 
-const { readFileSync } = require('fs');
+const { readFileSync, readdirSync } = require('fs');
 const { Serializer } = require('jsonapi-serializer');
 const { extname } = require('path');
 
@@ -22,8 +22,9 @@ const VersionsSerializer = new Serializer('version', {
 });
 
 const versions = yaml.safeLoad(readFileSync(`${guidesSrcPkg}/versions.yml`, 'utf8'));
+const allVersions = readdirSync(`${guidesSrcPkg}/guides/`);
 
-let premberVersions = [...versions.allVersions, 'release'];
+let premberVersions = [...allVersions, 'release'];
 
 const urls = premberVersions.map(version => `/${version}`);
 
@@ -44,7 +45,7 @@ premberVersions.forEach((premberVersion) => {
 // setting an ID so that it's not undefined
 versions.id = 'versions';
 
-const jsonTrees = versions.allVersions.map((version) => new StaticSiteJson(`${guidesSrcPkg}/guides/${version}`, {
+const jsonTrees = allVersions.map((version) => new StaticSiteJson(`${guidesSrcPkg}/guides/${version}`, {
   contentFolder: `content/${version}`,
   type: 'contents',
 }));


### PR DESCRIPTION
This is allowing us to preview upcoming versions of the guides that are **not available in the drop-down** of versions to pick from.