### PR TITLE
setting fastboot whitelist to the only possible hosts

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -24,7 +24,7 @@ module.exports = function(environment) {
     },
 
     fastboot: {
-      hostWhitelist: [/^[\w-]+\.herokuapp\.com$/, /^localhost:\d+$/, /^127\.0\.0\.1:\d+$/, /^[\w-]+\.fastly\.net$/]
+      hostWhitelist: [/^localhost:\d+$/, /^127\.0\.0\.1:\d+$/]
     },
 
     showdown: {


### PR DESCRIPTION
as this app is currently only ever being pre-built the only valid hosts are localhost and 127.0.0.1 👍 