### PR TITLE
[*] Remove patch versions & v prefix in version dropdown (#58)

### DIFF
--- a/app/helpers/shorten-version.js
+++ b/app/helpers/shorten-version.js
@@ -1,0 +1,7 @@
+import { helper } from '@ember/component/helper';
+
+export function shortenVersion([version='']) {
+  return version.slice(version.indexOf('v') + 1 || 0, version.lastIndexOf('.') === version.indexOf('.') ? version.length : version.lastIndexOf('.'));
+}
+
+export default helper(shortenVersion);

--- a/app/templates/version.hbs
+++ b/app/templates/version.hbs
@@ -1,7 +1,7 @@
 <aside class="sidebar">
   <label for="version-select" class="visually-hidden">Guides version</label>
   {{#power-select class="version-select" ariaLabel=model.version selected=model.version options=versions onchange=(action 'selectVersion') as |version|}}
-    {{version}}
+    {{shorten-version version}}
   {{/power-select}}
 
   <input id="toc-toggle" class="toc-toggle visually-hidden" type="checkbox" />

--- a/tests/acceptance/current-url-test.js
+++ b/tests/acceptance/current-url-test.js
@@ -10,6 +10,7 @@ module('Acceptance | current url', function(hooks) {
     await visit('/release');
     let page = this.owner.lookup('service:page');
     let currentVersion = page.get('currentVersion');
+    currentVersion = currentVersion.slice(currentVersion.indexOf('v') + 1 || 0, currentVersion.lastIndexOf('.') === currentVersion.indexOf('.') ? currentVersion.length : currentVersion.lastIndexOf('.'))
     assert.equal(find('.ember-basic-dropdown-trigger').textContent.trim(), currentVersion);
   });
 
@@ -19,6 +20,7 @@ module('Acceptance | current url', function(hooks) {
     assert.equal(currentURL(), "/release");
 
     let currentVersion = page.get('currentVersion');
+    currentVersion = currentVersion.slice(currentVersion.indexOf('v') + 1 || 0, currentVersion.lastIndexOf('.') === currentVersion.indexOf('.') ? currentVersion.length : currentVersion.lastIndexOf('.'))
     assert.equal(find('.ember-basic-dropdown-trigger').textContent.trim(), currentVersion);
   });
 });

--- a/tests/acceptance/dropdown-menu-test.js
+++ b/tests/acceptance/dropdown-menu-test.js
@@ -12,11 +12,11 @@ module('Acceptance | dropdown menu', function(hooks) {
   test('version navigation by dropdown menu', async function(assert) {
     await visit('/v2.17.0/models/');
     await click('.ember-basic-dropdown-trigger')
-    await click(selectOption("v2.10.0"))
+    await click(selectOption("2.10"))
     assert.equal(currentURL(), '/v2.10.0');
 
     await click('.ember-basic-dropdown-trigger')
-    await click(selectOption("v1.10.0"))
+    await click(selectOption("1.10"))
     assert.equal(currentURL(), '/v1.10.0');
   });
 });

--- a/tests/integration/helpers/shorten-version-test.js
+++ b/tests/integration/helpers/shorten-version-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Helper | shorten-version', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shortens version v3.2.0 to 3.2', async function(assert) {
+    this.set('inputValue', 'v3.2.0');
+    await render(hbs`{{shorten-version inputValue}}`);
+    assert.equal(this.element.textContent.trim(), '3.2');
+  });
+
+  test('it keeps version 3.2 without changes', async function(assert) {
+    this.set('inputValue', '3.2');
+    await render(hbs`{{shorten-version inputValue}}`);
+    assert.equal(this.element.textContent.trim(), '3.2');
+  });
+});


### PR DESCRIPTION
Added `shorten-version` that transforms version from `v3.2.0` -> `3.2` as explained in #58 
Basic test were added and 2 existing tests were modified.

Fixes #58 