### PR TITLE
fixing TOC in fastboot

### DIFF
--- a/app/templates/components/table-of-contents.hbs
+++ b/app/templates/components/table-of-contents.hbs
@@ -3,44 +3,21 @@
   {{#unless (or page.skipToc (get page 'skip-toc'))}}
     <li class="{{tocLevel}} {{if (eq currentPage.url page.url) 'selected'}}">
       {{#if page.pages}}
-        {{!-- cp-panel doesn't work in fastboot :( --}}
-        {{#if fastboot.isFastBoot}}
-
-          <div class="cp-Panel cp-is-{{if (eq currentSection.id page.id) 'open' 'closed'}}">
-            <a href="#" class="cp-Panel-toggle cp-is-open">
+        {{#cp-panel open=(eq currentSection.id page.id) as |p|}}
+          {{#if fastboot.isFastBoot}}
+            {{#link-to 'version.show' page.id activeClass="selected" class="cp-Panel-toggle" data-test-toc-link=page.title}}
               {{page.title}}
-            </a>
-            {{#if (eq currentSection.id page.id) }}
-            <div class="cp-Panel-body cp-is-{{if (eq currentSection.id page.id) 'open' 'closed'}}">
-              <div class="cp-Panel-body-inner">
-                {{!-- FASTBOOT BUG :( I will update the comment with link once it's reported --}}
-                {{!-- {{table-of-contents data=page.pages currentPage=currentPage level=(inc level)}} --}}
-                {{!-- <ol class="toc-level-1">
-                  {{#each page.pages as |innerPage|}}
-                    <li class="toc-level-1 {{if (eq currentPage.url page.url) 'selected'}}">
-                      {{#link-to 'version.show' innerPage.url}}
-                        {{innerPage.title}}
-                      {{/link-to}}
-                    </li>
-                  {{/each}}
-                </ol> --}}
-              </div>
-            </div>
-            {{/if}}
-          </div>
-
-        {{else}}
-          {{#cp-panel open=(eq currentSection.id page.id) as |p|}}
+            {{/link-to}}
+          {{else}}
             {{#p.toggle data-test-toc-title=page.title}}
               {{page.title}}
             {{/p.toggle}}
+          {{/if}}
 
-            {{#p.body}}
-              {{table-of-contents data=page.pages currentPage=currentPage level=(inc level)}}
-            {{/p.body}}
-          {{/cp-panel}}
-        {{/if}}
-
+          {{#p.body}}
+            {{table-of-contents data=page.pages currentPage=currentPage level=(inc level)}}
+          {{/p.body}}
+        {{/cp-panel}}
       {{else}}
         {{#link-to 'version.show' page.url activeClass="selected" data-test-toc-link=page.title}}
           {{page.title}}


### PR DESCRIPTION
This now fixes any issues someone might have trying to navigate using the Table of Contents with Javascript turned off.

I had a conversation with @xg-wang about previous issues we had with Fastboot and the TOC and it looks like the issue is now fixed https://github.com/ember-fastboot/fastboot/issues/183 

