### PR TITLE
remove jquery from guides-article -- add test

### DIFF
--- a/app/components/guides-article.js
+++ b/app/components/guides-article.js
@@ -6,19 +6,11 @@ export default Component.extend({
   classNames: 'chapter',
   page: service(),
   didRender() {
-
-    let nodeList = this.$('pre:not(.no-line-numbers) > code');
-
-    if (nodeList) {
-      nodeList.each((index, code) => {
-        code.parentNode.classList.add('line-numbers');
-      });
-    }
-
-    let filenameNodeList = this.$('pre > code[data-filename]');
+    this._addLineNumbers();
+    let filenameNodeList = this.element.querySelectorAll('pre > code[data-filename]');
 
     if (filenameNodeList) {
-      filenameNodeList.each((index, code) => {
+      filenameNodeList.forEach((code) => {
         if (code.parentNode.parentNode.classList.contains('filename')) {
           //do nothing
           return;
@@ -33,13 +25,49 @@ export default Component.extend({
           ext = match[1];
         }
 
-        this.$(code.parentNode).wrap(`<div class="filename ${ext}"></div>`);
+        let preNode = code.parentNode;
 
-        this.$(code.parentNode.parentNode).prepend(this.$(`<span>${code.attributes['data-filename'].value}</span>`));
-        this.$(code.parentNode.parentNode).prepend('<div class="ribbon"></div>');
+        this._wrapCodeBlock(preNode, ext);
+        this._addFilename(preNode, filename);
+        this._addRibbon(preNode);
       });
     }
 
+    this._addLinkAnchors();
+    this._addSymbolsAndHighlight(filenameNodeList);
+  },
+
+  // private
+  _addLineNumbers() {
+    let nodeList = this.element.querySelectorAll('pre:not(.no-line-numbers) > code');
+
+    if (nodeList.length) {
+      nodeList.forEach((code) => {
+        code.parentNode.classList.add('line-numbers');
+      });
+    }
+  },
+
+  _wrapCodeBlock(preNode, ext) {
+    let wrapper = document.createElement('div');
+    wrapper.classList.add('filename', ext);
+    preNode.parentNode.insertBefore(wrapper, preNode);
+    wrapper.appendChild(preNode);
+  },
+
+  _addFilename(preNode, filename) {
+    let span = document.createElement('span');
+    span.textContent = filename;
+    preNode.parentNode.insertBefore(span, preNode);
+  },
+
+  _addRibbon(preNode) {
+    let div = document.createElement('span');
+    div.classList.add('ribbon');
+    preNode.parentNode.insertBefore(div, preNode);
+  },
+
+  _addLinkAnchors() {
     let allHeaders = document.querySelectorAll("h1, h2, h3, h4, h5, h6")
 
     for (var element of allHeaders) {
@@ -51,22 +79,24 @@ export default Component.extend({
         element.insertBefore(link, element.firstElementChild);
       }
     }
+  },
 
+  /**
+   * Prism doesn't support diff & a secondary language highlighting.
+   *
+   * So first, we let prism convert the content of `<code></code>` blocks
+   * from a string into a different dom structure
+   * by calling `Prism.highlightAll()`
+   *
+   * In the following block, we add + & - symbols to the lines inside the
+   * code block based on the data-diff attribute on the code tag.
+   * e.g., data-diff="-4,+5,+6,+7"
+   *
+   **/
+
+  _addSymbolsAndHighlight(filenameNodeList) {
     Prism.highlightAll();
-
-    /**
-     * Prism doesn't support diff & a secondary language highlighting.
-     *
-     * So first, we let prism convert the content of `<code></code>` blocks
-     * from a string into a different dom structure
-     * by calling `Prism.highlightAll()`
-     *
-     * In the following block, we add + & - symbols to the lines inside the
-     * code block based on the data-diff attribute on the code tag.
-     * e.g., data-diff="-4,+5,+6,+7"
-     *
-     **/
-    filenameNodeList.each((_, codeBlock) => {
+    filenameNodeList.forEach((codeBlock) => {
 
       let diffInfo = codeBlock.attributes['data-diff'] ? codeBlock.attributes["data-diff"].value.split(',') : [];
 
@@ -87,7 +117,6 @@ export default Component.extend({
         }
       });
       codeBlock.innerHTML = lines.join('\n');
-    })
-
+    });
   }
 });

--- a/tests/integration/components/guides-article-test.js
+++ b/tests/integration/components/guides-article-test.js
@@ -47,11 +47,9 @@ module('Integration | Component | guides-article', function(hooks) {
 
     await render(hbs`{{guides-article model=model version=version currentVersion=currentVersion}}`);
 
-    let pageTitle = this.element.querySelector('h1');
-    let pageLink = this.element.querySelector('h1 a');
-    assert.notOk(this.element.querySelector('.old-version-warning'), 'no warning shown on current version');
-    assert.equal(pageTitle.textContent.trim(), 'Fresh Fish\n  Edit Page');
-    assert.equal(pageLink.href, `${GH_LINK}/v3.2.0/123.md`, 'correct guides OSS link is shown');
+    assert.dom('.old-version-warning').doesNotExist();
+    assert.dom('h1').hasText('Fresh Fish Edit Page');
+    assert.dom('h1 a').hasAttribute('href', `${GH_LINK}/v3.2.0/123.md`, 'correct guides OSS link is shown');
   });
 
   test('it formats code blocks', async function(assert) {
@@ -64,11 +62,10 @@ module('Integration | Component | guides-article', function(hooks) {
 
     await render(hbs`{{guides-article model=model version=version currentVersion=currentVersion}}`);
 
-    let filenameNode = this.element.querySelector('div.filename span');
-    assert.ok(this.element.querySelector('.old-version-warning'), 'warning is shown on older versions');
-    assert.equal(this.element.querySelectorAll('.line-numbers-rows span').length, 14, '14 lines are shown');
-    assert.equal(this.element.querySelectorAll('.diff-deletion').length, 3, '3 lines were removed');
-    assert.equal(this.element.querySelectorAll('.diff-insertion').length, 4, '4 lines were added');
-    assert.equal(filenameNode.textContent.trim(), 'tests/acceptance/list-rentals-test.js', 'filename is shown');
+    assert.dom('.old-version-warning').exists();
+    assert.dom('.line-numbers-rows span').exists({ count: 14 });
+    assert.dom('.diff-deletion').exists({ count: 3 });
+    assert.dom('.diff-insertion').exists({ count: 4 });
+    assert.dom('div.filename span').hasText('tests/acceptance/list-rentals-test.js', 'filename is shown');
   });
 });

--- a/tests/integration/components/guides-article-test.js
+++ b/tests/integration/components/guides-article-test.js
@@ -1,0 +1,74 @@
+/* eslint-disable ember/avoid-leaking-state-in-ember-objects */
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import Service from '@ember/service';
+
+const GH_LINK = 'https://github.com/ember-learn/guides-source/edit/master/guides';
+
+const ARTICLE = `
+\`\`\`javascript {data-filename="tests/acceptance/list-rentals-test.js" data-diff="+7,-8,+9,-10,+11,-12,+13"}
+import { module, test } from 'qunit';↵import { setupApplicationTest } from 'ember-qunit';
+import { visit, currentURL } from '@ember/test-helpers';
+
+module('Acceptance | my acceptance test', function(hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /list-rentals', async function(assert) {
+  test('visiting /', async function(assert) {
+    await visit('/list-rentals');
+    await visit('/');
+    assert.equal(currentURL(), '/list-rentals');
+    assert.equal(currentURL(), '/');
+  });
+});
+\`\`\`
+`;
+
+module('Integration | Component | guides-article', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it shows basic article information', async function(assert) {
+    this.set('version', 'v3.2.0');
+    this.set('currentVersion', 'v3.2.0');
+    this.set('model', {
+      content: 'Oh hi',
+      id: 123
+    });
+
+    let pageServiceStub = Service.extend({
+      currentPage: {
+        title: 'Fresh Fish'
+      },
+      currentVersion: 'v3.2.0'
+    });
+    this.owner.register('service:page', pageServiceStub);
+
+    await render(hbs`{{guides-article model=model version=version currentVersion=currentVersion}}`);
+
+    let pageTitle = this.element.querySelector('h1');
+    let pageLink = this.element.querySelector('h1 a');
+    assert.notOk(this.element.querySelector('.old-version-warning'), 'no warning shown on current version');
+    assert.equal(pageTitle.textContent.trim(), 'Fresh Fish\n  Edit Page');
+    assert.equal(pageLink.href, `${GH_LINK}/v3.2.0/123.md`, 'correct guides OSS link is shown');
+  });
+
+  test('it formats code blocks', async function(assert) {
+    this.set('version', 'v3.2.0');
+    this.set('currentVersion', 'v2.2.0');
+    this.set('model', {
+      content: ARTICLE,
+      id: 123
+    });
+
+    await render(hbs`{{guides-article model=model version=version currentVersion=currentVersion}}`);
+
+    let filenameNode = this.element.querySelector('div.filename span');
+    assert.ok(this.element.querySelector('.old-version-warning'), 'warning is shown on older versions');
+    assert.equal(this.element.querySelectorAll('.line-numbers-rows span').length, 14, '14 lines are shown');
+    assert.equal(this.element.querySelectorAll('.diff-deletion').length, 3, '3 lines were removed');
+    assert.equal(this.element.querySelectorAll('.diff-insertion').length, 4, '4 lines were added');
+    assert.equal(filenameNode.textContent.trim(), 'tests/acceptance/list-rentals-test.js', 'filename is shown');
+  });
+});


### PR DESCRIPTION
## What's in this PR?

There has been a lot of talk recently about Ember moving away from jQuery, so I wanted to look into formatting the guides articles without using jQuery.

This PR isolates some of the behavior in the `didRender` hook to private methods in a hope that it is easier to understand what each block is doing.

Also added an integration test to make sure links display properly and that code line numbers/highlight show up properly.