### PR TITLE
[bugfix] Prevents ligatures in codeblocks

### DIFF
--- a/app/styles/_code-block-file-name.scss
+++ b/app/styles/_code-block-file-name.scss
@@ -47,6 +47,13 @@ pre[class*="language-"] {
   background-image: url("../images/ribbon-hbs.svg");
 }
 
+code {
+  -webkit-font-feature-settings: "kern", "tnum";
+  -moz-font-feature-settings: "kern", "tnum";
+  -ms-font-feature-settings: "kern", "tnum";
+  font-feature-settings: "kern", "tnum";
+}
+
 code:not([class*="language-"]) {
   background-color: #F8E7CF;
   border-radius: 3px;
@@ -54,8 +61,4 @@ code:not([class*="language-"]) {
   font-size: 0.9em;
   padding: 0.2em 0.5em;
   margin: 0 0.1em;
-  -webkit-font-feature-settings: "kern", "tnum";
-  -moz-font-feature-settings: "kern", "tnum";
-  -ms-font-feature-settings: "kern", "tnum";
-  font-feature-settings: "kern", "tnum";
 }


### PR DESCRIPTION
Currently common ligatures are being applied to monospace fonts in
codeblocks. There are stylings in place to prevent this in inline
code segments, and in code blocks without languages. This PR pulls them
out into all code blocks.

<img width="663" alt="screen shot 2018-06-20 at 5 17 34 pm" src="https://user-images.githubusercontent.com/685518/41692034-b7d4e32e-74b2-11e8-8a2a-3820eafffd12.png">
