### PR TITLE
allow the ability for a markdown file to specify a redirect

### DIFF
--- a/app/models/content.js
+++ b/app/models/content.js
@@ -5,4 +5,5 @@ export default DS.Model.extend({
   content: DS.attr(),
   description: DS.attr(),
   canonical: DS.attr(),
+  redirect: DS.attr(),
 });

--- a/app/routes/version/show.js
+++ b/app/routes/version/show.js
@@ -45,6 +45,10 @@ export default Route.extend({
     })
   },
   afterModel(model) {
+    if(model.content.redirect) {
+      this.transitionTo('version.show', model.content.redirect)
+    }
+
     let content = get(model, 'content');
     set(this.page, 'content', content);
     let version = get(model, 'version');

--- a/lib/content-guides-generator/index.js
+++ b/lib/content-guides-generator/index.js
@@ -48,7 +48,7 @@ const jsonTrees = versions.allVersions.map((version) => new StaticSiteJson(`${gu
   contentFolder: `content/${version}`,
   contentTypes: ['content', 'description'],
   type: 'contents',
-  attributes: ['canonical'],
+  attributes: ['canonical', 'redirect'],
 }));
 
 var versionsFile = writeFile('/content/versions.json', JSON.stringify(VersionsSerializer.serialize(versions)));


### PR DESCRIPTION
This PR is necessary to allow for the redirect implementation defined in https://github.com/ember-learn/guides-source/pull/140 to not break existing links

for an example of how to define a redirect route: https://github.com/ember-learn/guides-source/pull/140/files#diff-54f5162d5170d0f3b50931a954064dd9R2

note: this is only intended to work *internally* inside a version. it's not going to work for any arbitrary external redirect 👍 