### PR TITLE
[WIP] fixing a rendering slowdown on safari

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -6,6 +6,11 @@
   font-style: normal;
 }
 
+// fixing a rendering issue on safari
+code[class*=language-], pre[class*=language-] {
+  text-shadow: unset;
+}
+
 [class^="icon-"]:before,
 [class*=" icon-"]:before {
   font-family: "fontello";


### PR DESCRIPTION
This originally came out of a user reaching out to me on twitter: https://twitter.com/happycollision/status/1036404778736250882

apparently the code examples have a lot of jank on Safari 🤔 Doing a little bit of investigation there seems to be quite a large **compositing** element in the render when you are scrolling left and right. I did some research on what can cause compositing like this on scroll and the only thing I could find (on first pass) was this text-shadow. 

I'm going to create a test app and reach out to Don to see if he can test this to see if it has improved things for him and if so then I think we should merge it 👍 