### PR TITLE
line-height in code tag inside any heading tag

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -964,6 +964,7 @@ h4 code,
 h5 code,
 h6 code {
   text-transform: none;
+  line-height: 2;
 }
 
 


### PR DESCRIPTION
I noticed there is a little issue with code tags inside headings when headings are multiline... 
I quick solved with line-height

Before line-height:
![image](https://user-images.githubusercontent.com/9092644/45012174-80e52680-afdb-11e8-8a6c-7984fe87faad.png)

After
![image](https://user-images.githubusercontent.com/9092644/45012232-c1dd3b00-afdb-11e8-9b23-a1a4e348df2e.png)
