### PR TITLE
Move edit link outside of H1 element. Fixes #249

### DIFF
--- a/app/templates/components/guides-article.hbs
+++ b/app/templates/components/guides-article.hbs
@@ -6,10 +6,11 @@
  </div>
 {{/unless}}
 
+<a href="https://github.com/ember-learn/guides-source/edit/master/guides/{{page.currentVersion}}/{{model.id}}.md"
+  target="_blank" class="edit-page icon-pencil">Edit Page</a>
+
 <h1>
   {{page.currentPage.title}}
-  <a href="https://github.com/ember-learn/guides-source/edit/master/guides/{{page.currentVersion}}/{{model.id}}.md"
-     target="_blank" class="edit-page icon-pencil">Edit Page</a>
 </h1>
 <hr>
 


### PR DESCRIPTION
Not sure if there is a preference to have this before or after the H1 in terms of source order, but this gets it out of the H1 element and retains the current styling with no further CSS changes required.