### PR TITLE
Add base line-height to <article>

### DIFF
--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1244,6 +1244,7 @@ body {
 }
 
 article {
+  line-height: 1.5;
   padding: 3em 0;
   @media screen and (min-width: 53.75em) {
     float: left;


### PR DESCRIPTION
I noticed the line-height is wrong on list items in the Guides:

![image](https://user-images.githubusercontent.com/2922250/49826551-2800f900-fd55-11e8-830b-6d23016f3eae.png)

<p> tags get it from a global rule, but instead of adding another global rule for <li> elements I think it makes the most sense to add it as a base rule for <article> elements (so everything inside defaults to the same leading).