### PR TITLE
Add no search result display

### DIFF
--- a/app/components/dropdown-header.js
+++ b/app/components/dropdown-header.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['ds-suggestion']
+});

--- a/app/components/search-input.js
+++ b/app/components/search-input.js
@@ -1,19 +1,18 @@
 import { getOwner } from '@ember/application';
 import Component from '@ember/component';
-import { computed, set } from '@ember/object';
-import { later } from '@ember/runloop';
+import { get, set } from '@ember/object';
+import { and } from '@ember/object/computed';
 import { inject as service } from '@ember/service';
-import algoliasearch from 'algoliasearch';
 import { task, timeout } from 'ember-concurrency';
-import { denodeify } from 'rsvp';
-
 
 const SEARCH_DEBOUNCE_PERIOD = 300;
+const SEARCH_CLOSE_PERIOD = 200;
 
 export default Component.extend({
   classNames: ['search-input'],
 
-  page: service(),
+  // page: service(),
+  searchService: service('search'),
 
   _resultTetherConstraints: Object.freeze([
     {
@@ -22,69 +21,47 @@ export default Component.extend({
     }
   ]),
 
+  _focused: false,
+
   init() {
     this._super(...arguments);
     const config = getOwner(this).resolveRegistration('config:environment');
-
-    const { algoliaId, algoliaKey } = config['ember-algolia'];
-
-    this.client = algoliasearch(algoliaId, algoliaKey);
-    this.index = this.client.initIndex('ember-guides');
-    this.searchFunction = denodeify(this.index.search.bind(this.index));
+    this.deprecationsGuideURL = config['deprecationsGuideURL'];
   },
 
-  pageIndex: computed('page.pages.[]', function() {
-    let pages = this.page.pages.map((section) => {
-      return section.pages.map(page => {
-          return {
-            section: section.title,
-            page: page.title,
-            fullTitle: `${section.title} > ${page.title}`,
-            url: page.url.replace(/\/index$/, '')
-          }
-      })
-    });
-
-    return pages.reduce((a, b) => a.concat(b), []);
-  }),
+  showDropdown: and('query', '_focused'),
 
   search: task(function * (query) {
+
     yield timeout(SEARCH_DEBOUNCE_PERIOD);
 
-    if(!query) {
-      return set(this, 'response', null);
+    set(this, 'query', query);
+
+    // Hide and don't run query if there's no search query
+    if (!query) {
+      return set(this, '_focused', false);
     }
 
-    const projectVersion = this.projectVersion;
+    // ensure search results are visible if the menu was previously closed above
+    set(this, '_focused', true);
 
-    const searchObj = {
-      hitsPerPage: 15,
-      restrictSearchableAttributes: ['content'],
-      facetFilters: [[`version:${projectVersion}`]],
-      query
-    };
+    yield get(this, 'searchService.search').perform(query, this.projectVersion);
 
-    let res = yield this.searchFunction(searchObj);
-
-    return set(this, 'response', res);
   }).restartable(),
 
-  actions: {
-    oninput(value) {
-      set(this, 'value', value);
-      if(value) {
-        this.search.perform(value);
-      }
-    },
+  closeMenu: task(function * () {
+    yield timeout(SEARCH_CLOSE_PERIOD);
 
+    set(this, '_focused', false);
+  }),
+
+  actions: {
     onfocus() {
       set(this, '_focused', true);
     },
 
     onblur() {
-      later(this, function () {
-        set(this, '_focused', false);
-      }, 200);
+      this.get('closeMenu').perform();
     }
 
   }

--- a/app/services/search.js
+++ b/app/services/search.js
@@ -1,0 +1,37 @@
+import Service from '@ember/service';
+import { task } from 'ember-concurrency';
+import { get, set } from '@ember/object';
+import { A as emberArray } from '@ember/array';
+import { denodeify } from 'rsvp';
+import algoliasearch from 'algoliasearch';
+import { getOwner } from '@ember/application';
+
+export default Service.extend({
+
+  results: emberArray(),
+
+  search: task(function * (query, projectVersion) {
+    const searchObj = {
+      hitsPerPage: 15,
+      restrictSearchableAttributes: ['content'],
+      facetFilters: [[`version:${projectVersion}`]],
+      query
+    };
+
+    return set(this, 'results', yield this.doSearch(searchObj));
+
+  }).restartable(),
+
+  doSearch(searchObj) {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    const { algoliaId, algoliaKey } = config['ember-algolia'];
+
+    const client = algoliasearch(algoliaId, algoliaKey);
+    const index = client.initIndex('ember-guides');
+    const searchFunction = denodeify(index.search.bind(index));
+
+    return searchFunction(searchObj).then((results) => {
+      return get(results, 'hits');
+    });
+  }
+});

--- a/app/styles/_search-input.scss
+++ b/app/styles/_search-input.scss
@@ -155,6 +155,15 @@ $dropdown-min-width-large: 600px;
   text-align: left;
 }
 
+// No Results
+.algolia-docsearch-suggestion--noresults {
+  padding: 0 5px 10px 10px;
+  a {
+    color: $ember-orange;
+    text-decoration: none;
+  }
+}
+
 // Each suggestion
 .algolia-docsearch-suggestion {
   color: #333;

--- a/app/templates/components/dropdown-header.hbs
+++ b/app/templates/components/dropdown-header.hbs
@@ -1,0 +1,8 @@
+<div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main">
+  <div class="algolia-docsearch-suggestion--category-header">
+    <span class="algolia-docsearch-suggestion--category-header-lvl0">
+      {{yield}}
+    </span>
+  </div>
+  <div class="algolia-docsearch-suggestion--wrapper"></div>
+</div>

--- a/app/templates/components/search-input.hbs
+++ b/app/templates/components/search-input.hbs
@@ -2,9 +2,11 @@
   id='search-input'
   type='search'
   value={{value}}
-    oninput={{perform search value='target.value'}}
+  oninput={{perform search value='target.value'}}
   placeholder="Search the guides"
   autocomplete="off"
+  onfocus={{action 'onfocus'}}
+  onblur={{action 'onblur'}}
 >
 
 {{!-- Search results dropdown --}}
@@ -15,20 +17,20 @@
   constraints=_resultTetherConstraints
   class='ds-dropdown-results'
 }}
-  {{#if response.hits}}
+  {{#if showDropdown}}
     <span class="ds-suggestions ds-dropdown-menu">
-      <div class="ds-suggestion">
-        <div class="algolia-docsearch-suggestion algolia-docsearch-suggestion__main">
-          <div class="algolia-docsearch-suggestion--category-header">
-            <span class="algolia-docsearch-suggestion--category-header-lvl0">
-                    Search Results
-            </span>
-          </div>
-          <div class="algolia-docsearch-suggestion--wrapper"></div>
-        </div>
-      </div>
-      {{#each response.hits as |result|}}
+      {{#dropdown-header}}
+          Search Results
+      {{/dropdown-header}}
+
+      {{#each searchService.results as |result|}}
         {{search-result result=result}}
+      {{else}}
+        <div class="algolia-docsearch-suggestion">
+          <div class="algolia-docsearch-suggestion--noresults">
+            <p>No results found. Try searching the <a href="{{deprecationsGuideURL}}" target="_deprecations">deprecations guide</a>.</p>
+          </div>
+        </div>
       {{/each}}
       <div class="powered-by-algolia">
         <a href="https://www.algolia.com/" target="_blank">

--- a/config/environment.js
+++ b/config/environment.js
@@ -60,6 +60,8 @@ module.exports = function(environment) {
       twitterUsername: '@emberjs',
       url: 'https://guides.emberjs.com/'
     },
+
+    deprecationsGuideURL: 'https://www.emberjs.com/deprecations/'
   };
 
   if (environment === 'development') {
@@ -80,6 +82,11 @@ module.exports = function(environment) {
 
     ENV.APP.rootElement = '#ember-testing';
     ENV.APP.autoboot = false;
+
+    ENV['ember-tether'] = {
+      bodyElementId: 'ember-testing'
+    };
+
   }
 
   if (environment === 'production') {

--- a/tests/integration/components/dropdown-header-test.js
+++ b/tests/integration/components/dropdown-header-test.js
@@ -1,0 +1,26 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+module('Integration | Component | dropdown-header', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it renders', async function(assert) {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{dropdown-header}}`);
+
+    assert.equal(this.element.textContent.trim(), '');
+
+    // Template block usage:
+    await render(hbs`
+      {{#dropdown-header}}
+        template block text
+      {{/dropdown-header}}
+    `);
+
+    assert.equal(this.element.textContent.trim(), 'template block text');
+  });
+});

--- a/tests/integration/components/search-input-test.js
+++ b/tests/integration/components/search-input-test.js
@@ -1,0 +1,24 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { set } from '@ember/object';
+
+module('Integration | Component | search input', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('no search hits display no results', async function(assert) {
+
+    let searchService = this.owner.lookup('service:search');
+
+    set(searchService, 'doSearch', () => {
+      return [];
+    });
+
+    await this.render(hbs`{{search-input}}`);
+
+    await fillIn('#search-input', 'model');
+
+    assert.dom('.algolia-docsearch-suggestion--noresults').exists();
+  });
+});

--- a/tests/unit/services/search-test.js
+++ b/tests/unit/services/search-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | search', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    let service = this.owner.lookup('service:search');
+    assert.ok(service);
+  });
+});


### PR DESCRIPTION
When there are no search results, display a link to the deprecations guide.  This will match the functionality of what is currently in ember-api-docs.