### PR TITLE
add cli guides to the navbar

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -13,6 +13,10 @@ const links = [{
     name: 'API Reference',
     type: 'link'
   }, {
+    href: 'https://cli.emberjs.com',
+    name: 'CLI Guides',
+    type: 'link'
+  }, {
     type: 'divider'
   }, {
     href: 'https://emberjs.com/learn',

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -6,7 +6,7 @@ const links = [{
   type: 'dropdown',
   items: [{
     href: 'https://guides.emberjs.com',
-    name: 'Guides',
+    name: 'Ember.js Guides',
     type: 'link'
   }, {
     href: 'https://emberjs.com/api',


### PR DESCRIPTION
Turns out that we don't use the ember-styleguide defaults, so I added it to the links list that is local to this repo.