### PR TITLE
fix 404 when clicking on old version warning button

### DIFF
--- a/app/components/guides-article.js
+++ b/app/components/guides-article.js
@@ -89,5 +89,10 @@ export default Component.extend({
       codeBlock.innerHTML = lines.join('\n');
     })
 
+  },
+  actions: {
+    selectVersion (currentVersion) {
+      this.selectVersion(currentVersion);
+    }
   }
 });

--- a/app/templates/components/guides-article.hbs
+++ b/app/templates/components/guides-article.hbs
@@ -1,8 +1,7 @@
 {{#unless (eq version currentVersion)}}
  <div class="old-version-warning">
    <i class="icon-attention-circled"></i><strong>Old Guides - </strong>You are viewing the guides for Ember {{version}}.
-
-   {{#link-to 'version.show' 'release' path class="btn"}} VIEW {{currentVersion}} {{/link-to}}
+    <button onclick={{action "selectVersion" currentVersion}} class="btn">VIEW {{currentVersion}} </button>
  </div>
 {{/unless}}
 

--- a/app/templates/version/index.hbs
+++ b/app/templates/version/index.hbs
@@ -1,1 +1,1 @@
-{{guides-article model=model.content pages=model.pages path='index' version=model.version currentVersion=model.currentVersion}}
+{{guides-article model=model.content pages=model.pages path='index' version=model.version currentVersion=model.currentVersion selectVersion=(action 'selectVersion')}}

--- a/app/templates/version/show.hbs
+++ b/app/templates/version/show.hbs
@@ -1,1 +1,1 @@
-{{guides-article model=model.content pages=model.pages path=model.path version=model.version currentVersion=model.currentVersion}}
+{{guides-article model=model.content pages=model.pages path=model.path version=model.version currentVersion=model.currentVersion selectVersion=(action 'selectVersion')}}


### PR DESCRIPTION
Hi, here's most of a fix for this issue:
https://github.com/ember-learn/guides-source/issues/495

Can I please get some quick help on the correct syntax for passing closure actions? (I haven't written Ember in quite a while and have gotten a bit rusty)

I'm currently getting the following error when trying to run this code:
```
^C/var/folders/60/6v2xklpj56dffwcgp24p06_c0000gn/T/broccoli-29915oxu74ikNfIOQ/out-482-broccoli_merge_trees/assets/vendor.js:34527
                    throw new Error('infinite rendering invalidation detected');
```