### PR TITLE
update engines tag to valid LTS node version (10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "showdown-section-groups": "^0.3.0"
   },
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": ">= 10.*"
   },
   "ember-addon": {
     "paths": [


### PR DESCRIPTION
When getting the guides app up and running I found that it will not run with node < 8, recommend we support node 10+ (LTS).
https://github.com/ember-learn/guides-app/issues/400#issuecomment-477032458